### PR TITLE
Updating all dependencies. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,19 +6,19 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.3.RELEASE</version>
+        <version>2.7.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>bootiful.asciidoctor</groupId>
     <packaging>pom</packaging>
     <artifactId>parent</artifactId>
     <name>bootiful-asciidoctor</name>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
     <properties>
-        <aws-java-sdk.version>1.11.567</aws-java-sdk.version>
-        <asciidoctorj-pdf.version>1.5.0-alpha.16</asciidoctorj-pdf.version>
-        <asciidoctorj-epub3.version>1.5.0-alpha.18</asciidoctorj-epub3.version>
-        <java.version>11</java.version>
+        <aws-java-sdk.version>1.12.352</aws-java-sdk.version>
+        <asciidoctorj-pdf.version>2.3.3</asciidoctorj-pdf.version>
+        <asciidoctorj-epub3.version>1.5.1</asciidoctorj-epub3.version>
+        <java.version>17</java.version>
     </properties>
     <modules>
         <module>asciidoctor-autoconfiguration</module>
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctorj</artifactId>
-                <version>1.5.6</version>
+                <version>2.5.7</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jruby</groupId>


### PR DESCRIPTION
This is mostly because we need updated Asciidoctor-pdf to use recent features. I have chosen not to upgrade to Spring Boot 3 at this stage because I have not tested it.